### PR TITLE
cansmoothwith

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -366,6 +366,23 @@
 		/obj/machinery/door/airlock/science/glass, \
 		/obj/machinery/door/airlock/science/neutral, \
 		/obj/machinery/door/airlock/maintenance_hatch, \
+		/obj/machinery/door/airlock/maintenance_hatch, \
+		/turf/simulated/wall/mineral/plastic, \
+		/obj/machinery/door/traindoor, \
+		/obj/structure/mineral_door/wood/single, \
+		/obj/structure/mineral_door/wood/double, \
+		/obj/structure/mineral_door/wood/doubledirty, \
+		/obj/structure/mineral_door/transparent/wood, \
+		/obj/structure/mineral_door/transparent/wooddouble, \
+		/obj/structure/mineral_door/transparent/metal, \
+		/obj/structure/mineral_door/transparent/automatic, \
+		/obj/structure/mineral_door/transparent/traindouble, \
+		/obj/structure/mineral_door/transparent/trainglass, \
+		/obj/structure/mineral_door/metal/automatic, \
+		/obj/structure/mineral_door/metal/reinforced, \
+		/obj/structure/mineral_door/metal/train, \
+		/obj/machinery/door/poddoor/gateleft, \
+		/obj/machinery/door/poddoor/gateright, \
 )
 
 #define SMOOTH_ADAPTERS_WALLS list( \

--- a/trainstation13/code/trainturf.dm
+++ b/trainstation13/code/trainturf.dm
@@ -32,7 +32,7 @@
 	icon = 'trainstation13/icons/turf/plastic_wall.dmi'
 	mineral = "plastic"
 	sheet_type = /obj/item/stack/sheet/mineral/plastic
-	canSmoothWith = list(/turf/simulated/wall/mineral/plastic, /turf/simulated/wall/mineral/plastic)
+	canSmoothWith = CAN_SMOOTH_WITH_WALLS
 
 //MOVING - ANIMATED TURFS
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Включает сглаживание для стен с другими объектами:
![Tau Ceti Station 2023-07-18 011636](https://github.com/BartNixon/TrainStation13/assets/4064061/0957643a-0eec-48b6-a107-5acf05029fc6)
Может не нужно, я не знаю, я просто мимо проходил.

Можно включить еще адаптеры для дверей, как у обычных стен у нас, но двери на поезде в большинстве своём уже имеют какие-то вертикальные бордюры на спрайте. Не хватает горизонтальных только.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
